### PR TITLE
Fix hardcoded namespace D: in webdav client

### DIFF
--- a/source/RenderView.ts
+++ b/source/RenderView.ts
@@ -170,6 +170,11 @@ export default class RenderView extends Publisher implements IManip
         for (let i = 0, n = viewports.length; i < n; ++i) {
             const viewport = viewports[i];
 
+            // Remove when Webkit bug is fixed: https://bugs.webkit.org/show_bug.cgi?id=237230
+            let gl = renderer.getContext();
+            gl.clear(gl.DEPTH_BUFFER_BIT);
+            gl.finish(); 
+
             renderer["__viewport"] = viewport;
             const currentCamera = viewport.updateCamera(camera);
             viewport.applyViewport(this.renderer);

--- a/source/RenderView.ts
+++ b/source/RenderView.ts
@@ -5,7 +5,7 @@
  * License: MIT
  */
 
-import { WebGLRenderer, Object3D, Camera, Scene, Box3, Vector3 } from "three";
+import { WebGLRenderer, Object3D, Camera, Scene, Box3, Vector3, sRGBEncoding } from "three";
 
 import Publisher from "@ff/core/Publisher";
 import System from "@ff/graph/System";
@@ -84,6 +84,7 @@ export default class RenderView extends Publisher implements IManip
         this.renderer.autoClear = false;
         //this.renderer.gammaOutput = true;
         this.renderer.gammaFactor = 2;
+        this.renderer.outputEncoding = sRGBEncoding;
 
         this.picker = new GPUPicker(this.renderer);
     }
@@ -182,13 +183,19 @@ export default class RenderView extends Publisher implements IManip
         this.canvas.height = height;
 
         this.viewports.forEach(viewport => viewport.setCanvasSize(width, height));
-        this.renderer.setSize(width, height, false);
+
+        if(!this.renderer.xr.isPresenting) {
+            this.renderer.setSize(width, height, false);
+        }
     }
 
     resize()
     {
         this.setRenderSize(this.canvas.clientWidth, this.canvas.clientHeight);
-        this.render();
+
+        if(!this.renderer.xr.isPresenting) {
+            this.render();
+        }
     }
 
     setViewportCount(count: number)

--- a/source/RenderView.ts
+++ b/source/RenderView.ts
@@ -83,7 +83,7 @@ export default class RenderView extends Publisher implements IManip
 
         this.renderer.autoClear = false;
         //this.renderer.gammaOutput = true;
-        this.renderer.gammaFactor = 2;
+        //this.renderer.gammaFactor = 2;
         this.renderer.outputEncoding = sRGBEncoding;
 
         this.picker = new GPUPicker(this.renderer);

--- a/source/assets/WebDAVProvider.ts
+++ b/source/assets/WebDAVProvider.ts
@@ -239,7 +239,7 @@ export default class WebDAVProvider
             type: contentType ? contentType.elements[0].text as string : "",
         };
 
-        let path = new URL(info.url).pathname;
+        let path = new URL(info.url, this._rootUrl).pathname;
         const index = path.indexOf(this._rootPath);
         if (index >= 0) {
             path = path.substr(index + this._rootPath.length);

--- a/source/assets/WebDAVProvider.ts
+++ b/source/assets/WebDAVProvider.ts
@@ -97,11 +97,16 @@ export default class WebDAVProvider
             props.headers["Depth"] = "1";
         }
 
+        const controller = new AbortController();
+        const id = setTimeout(() => controller.abort(), 8000);
+        props["signal"] = controller.signal;
+
         return fetch(url, props).then(response => {
                 if (!response.ok) {
                     throw new Error(`failed to get content: ${response.status} ${response.statusText}`);
                 }
 
+                clearTimeout(id);
                 return response.text();
             })
             .then(xml => xmlTools.xml2js(xml))
@@ -226,7 +231,7 @@ export default class WebDAVProvider
 
         const info: Partial<IFileInfo> = {
             url: decodeURI(element.dict["D:href"].elements[0].text as string),
-            name: decodeURI(prop.dict["D:displayname"].elements[0].text as string),
+            name: decodeURI(prop.dict["D:displayname"].elements ? prop.dict["D:displayname"].elements[0].text as string : ""),
             created: prop.dict["D:creationdate"].elements[0].text as string,
             modified: prop.dict["D:getlastmodified"].elements[0].text as string,
             folder: isCollection,

--- a/source/components/CAssetManager.ts
+++ b/source/components/CAssetManager.ts
@@ -199,7 +199,7 @@ export default class CAssetManager extends Component
                         children: []
                     };
 
-                    this._assetsByPath[info.path] = asset;
+                    this._assetsByPath[decodeURI(info.path)] = asset;
                     entry.children.push(asset);
                 }
             }

--- a/source/components/CAssetManager.ts
+++ b/source/components/CAssetManager.ts
@@ -51,6 +51,9 @@ export default class CAssetManager extends Component
     get root() {
         return this._rootAsset;
     }
+    set root(asset: IAssetEntry) {
+        this._rootAsset = asset;
+    }
     get rootPath() {
         return this._provider.rootPath;
     }

--- a/source/components/CCamera.ts
+++ b/source/components/CCamera.ts
@@ -118,7 +118,7 @@ export default class CCamera extends CObject3D
 
         const orderName = order.getOptionText();
         _euler.setFromQuaternion(_quat, orderName);
-        _euler.toVector3(_vec3a);
+        _vec3a.setFromEuler(_euler);
         _vec3a.multiplyScalar(math.RAD2DEG).toArray(rotation.value);
 
         position.set(silent);

--- a/source/components/CMaterial.ts
+++ b/source/components/CMaterial.ts
@@ -95,7 +95,6 @@ export default class CMaterial extends Component
         if (ins.blending.changed || ins.transparent.changed || ins.flat.changed || ins.fog.changed) {
             material.blending = _THREE_BLENDING[ins.blending.getValidatedValue()];
             material.transparent = ins.transparent.value;
-            material.flatShading = ins.flat.value;
             material.fog = ins.fog.value;
         }
         if (ins.writeColor.changed || ins.writeDepth.changed || ins.testDepth.changed || ins.depthFunc.changed) {

--- a/source/components/CMaterial.ts
+++ b/source/components/CMaterial.ts
@@ -95,7 +95,6 @@ export default class CMaterial extends Component
         if (ins.blending.changed || ins.transparent.changed || ins.flat.changed || ins.fog.changed) {
             material.blending = _THREE_BLENDING[ins.blending.getValidatedValue()];
             material.transparent = ins.transparent.value;
-            material.fog = ins.fog.value;
         }
         if (ins.writeColor.changed || ins.writeDepth.changed || ins.testDepth.changed || ins.depthFunc.changed) {
             material.colorWrite = ins.writeColor.value;

--- a/source/components/CPickSelection.ts
+++ b/source/components/CPickSelection.ts
@@ -17,6 +17,7 @@ import { IPointerEvent } from "../RenderView";
 import CObject3D from "./CObject3D";
 import CTransform from "./CTransform";
 import CScene, { ISceneAfterRenderEvent } from "./CScene";
+import { DirectionalLight, DirectionalLightHelper } from "three";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -31,7 +32,7 @@ export default class CPickSelection extends CSelection
 
     ins = this.addInputs<CSelection, typeof _inputs>(_inputs);
 
-    private _brackets = new Map<Component, Bracket>();
+    private _brackets = new Map<Component, any>();
     private _sceneTracker: ComponentTracker<CScene> = null;
 
 
@@ -121,6 +122,9 @@ export default class CPickSelection extends CSelection
         const camera = event.context.camera;
 
         for (let entry of this._brackets) {
+            if(entry[1] instanceof DirectionalLightHelper) {
+                entry[1].update();
+            }
             renderer.render(entry[1] as any, camera);
         }
     }
@@ -134,8 +138,14 @@ export default class CPickSelection extends CSelection
         if (selected) {
             const object3D = component.object3D;
             if (object3D) {
-                const bracket = new Bracket(component.object3D);
-                this._brackets.set(component, bracket);
+                if(object3D.children[0] instanceof DirectionalLight) {
+                    const helper = new DirectionalLightHelper( object3D.children[0], 1.0, 0xffd633 );
+                    this._brackets.set(component, helper);
+                }
+                else {
+                    const bracket = new Bracket(component.object3D);
+                    this._brackets.set(component, bracket);
+                }
             }
         }
         else {

--- a/source/components/CRenderer.ts
+++ b/source/components/CRenderer.ts
@@ -220,7 +220,9 @@ export default class CRenderer extends Component
             }
 
             this.views.forEach(view => {
-                view.render();
+                if(!view.renderer.xr.isPresenting) {
+                    view.render();
+                }
             });
 
             this._forceRender = false;

--- a/source/components/CRenderer.ts
+++ b/source/components/CRenderer.ts
@@ -147,7 +147,7 @@ export default class CRenderer extends Component
             this.views.forEach(view => view.renderer.toneMappingExposure = ins.exposure.value);
         }
         if (ins.gamma.changed) {
-            this.views.forEach(view => view.renderer.gammaFactor = ins.gamma.value);
+            /*this.views.forEach(view => view.renderer.gammaFactor = ins.gamma.value);
 
             const scene = this.activeScene;
             if (scene) {
@@ -162,7 +162,7 @@ export default class CRenderer extends Component
                         }
                     }
                 });
-            }
+            }*/
         }
 
         if (ins.shadowsEnabled.changed) {

--- a/source/components/CTexture.ts
+++ b/source/components/CTexture.ts
@@ -20,7 +20,6 @@ export enum EMappingMode {
     CubeRefraction,
     EquiRectReflection,
     EquiRectRefraction,
-    SphericalReflection,
     CubeUVReflection,
     CubeUVRefraction,
 }
@@ -31,7 +30,6 @@ const _THREE_MAPPING_MODE = [
     constants.CubeRefractionMapping,
     constants.EquirectangularReflectionMapping,
     constants.EquirectangularRefractionMapping,
-    constants.SphericalReflectionMapping,
     constants.CubeUVReflectionMapping,
     constants.CubeUVRefractionMapping,
 ];

--- a/source/components/CTexture.ts
+++ b/source/components/CTexture.ts
@@ -31,7 +31,6 @@ const _THREE_MAPPING_MODE = [
     constants.EquirectangularReflectionMapping,
     constants.EquirectangularRefractionMapping,
     constants.CubeUVReflectionMapping,
-    constants.CubeUVRefractionMapping,
 ];
 
 export enum EWrapMode {

--- a/source/components/CTexture.ts
+++ b/source/components/CTexture.ts
@@ -64,8 +64,8 @@ const _THREE_MIPMAP_FILTER_MODE = [
 export enum EEncodingType {
     Linear,
     sRGB,
-    Gamma,
-    RGBE,
+    //Gamma,
+    //RGBE,
     // LogLuv,
     // RGBM7,
     // RGBM16,
@@ -75,12 +75,12 @@ export enum EEncodingType {
 const _THREE_ENCODING_TYPE = [
     constants.LinearEncoding,
     constants.sRGBEncoding,
-    constants.GammaEncoding,
-    constants.RGBEEncoding,
-    constants.LogLuvEncoding,
-    constants.RGBM7Encoding,
-    constants.RGBM16Encoding,
-    constants.RGBDEncoding
+    //constants.GammaEncoding,
+    //constants.RGBEEncoding,
+    //constants.LogLuvEncoding,
+    //constants.RGBM7Encoding,
+    //constants.RGBM16Encoding
+    //constants.RGBDEncoding
 ];
 
 export default class CTexture extends Component

--- a/source/components/CTransform.ts
+++ b/source/components/CTransform.ts
@@ -132,7 +132,7 @@ export default class CTransform extends CHierarchy implements ICObject3D
 
         const orderName = order.getOptionText();
         _euler.setFromQuaternion(_quat, orderName);
-        _euler.toVector3(_vec3a);
+        _vec3a.setFromEuler(_euler);
         _vec3a.multiplyScalar(math.RAD2DEG).toArray(rotation.value);
 
         _vec3b.toArray(scale.value);


### PR DESCRIPTION
WEBDAVProvider.ts refers to response elements by a fixed choice of namespace prefix: `D:`.
But in practice, webdav servers may respond with elements with other prefixes for the same namespace.

That will break the interpretation of the response.

What is more robust is: strip the namespace prefixes from the response elements, and in the WEBDAVProvider.ts remove all references to `D:`.

This is still not ideal, because in theory a webdav provider might answer with a response document containing elements in several name spaces.

But at least it is an improvement.

I checked this code inside a built version of voyager-story and it works.